### PR TITLE
Add ACI Core Interest Group WG Charter

### DIFF
--- a/members/wg-aci-cig.md
+++ b/members/wg-aci-cig.md
@@ -1,0 +1,31 @@
+# ACI Core Interest Group
+
+## Charter of the ACI Core Interest Group
+
+The ACI Core Interest Group shall be chartered to perform the following:
+* Any Action authorized to the Maintenance Team in respect to the ACI Specification,
+* Interface and Negotiate with the LC Project to smoothly establish the joint ACI Specification Project,
+* Act as the ACI Specification Project Core Interest Group on behalf of the Clever-ISA Project,
+* Act as the Registrar for the ACI Registries on behalf of the Clever-ISA Project, and
+* Act as the Registrar for subclass and product registries owned by the Clever-ISA Project.
+
+Any Action granted to the ACI Core Interest Group shall be non-exclusive as to the Maintenance Team. 
+
+## Membership of the ACI Core Interest Group
+
+The Initial Membership of the ACI Core Interest Group shall be set by the Maintenance Team, and subsequent changes shall also be conducted by the Maintenance Team but changes should not be made without consent or petition of the Maintenance Team.
+
+## Consensus
+
+The ACI Core Interest Group shall operate by consensus decision making. For actions that are not given to individual members, a Member of the ACI Core Interest Group may raise the action, which should then be reviewed by all Members of the Working Group. 
+
+The Action is taken once the required approval threshold has been reached, no outstanding objections have been made by a member of the Working Group, and one of the following has occured:
+1. All Members have approved the action, or
+2. At least 5 days have passed since the approval threshold has been reached.
+
+The Required Number of Approvals before an action can be approved depends on the number of Members on the Working Group:
+* 6 or fewer members: 2/3s of the Members of the Working Group,
+* 7 to 15 members: 3 fewer than the number of members of the Working Group,
+* 15 or more members: 5 fewer than the number of members of the Working Group, or 12 members, whichever is greater.
+
+If a substantive objection is raised by a Member of the Working Group, it stays approval of the action until it is withdrawn by the member, or overruled. An Objection may be overruled by all other members of the Working Group affirmatively voting to overrule the objection.

--- a/members/wg-aci-cig.md
+++ b/members/wg-aci-cig.md
@@ -6,8 +6,9 @@ The ACI Core Interest Group shall be chartered to perform the following:
 * Any Action authorized to the Maintenance Team in respect to the ACI Specification,
 * Interface and Negotiate with the LC Project to smoothly establish the joint ACI Specification Project,
 * Act as the ACI Specification Project Core Interest Group on behalf of the Clever-ISA Project,
-* Act as the Registrar for the ACI Registries on behalf of the Clever-ISA Project, and
-* Act as the Registrar for subclass and product registries owned by the Clever-ISA Project.
+* Act as the Registrar for the ACI Registries on behalf of the Clever-ISA Project,
+* Act as the Registrar for subclass and product registries owned by the Clever-ISA Project, and
+* Generally Manage the Affairs of the Working Group as a Working Group and in respect to the operations and governance of the Clever-ISA project.
 
 Any Action granted to the ACI Core Interest Group shall be non-exclusive as to the Maintenance Team. 
 


### PR DESCRIPTION
This charters the ACI Core Interest Group.

Per the Special Governance Grant respecting Working Group Charters, this may be merged by consensus of the Maintenance Team.